### PR TITLE
Preserve return value of original method

### DIFF
--- a/ruby-method-hooks/lib/hooks.rb
+++ b/ruby-method-hooks/lib/hooks.rb
@@ -26,12 +26,14 @@ module Hooks
           hook[:block].call(*args) unless hook[:except].include? method_name
         end
 
-        original_method.bind(self).call(*args, &block)
+        result = original_method.bind(self).call(*args, &block)
 
         after_all_hooks = self.class.instance_variable_get(:@after_all_hooks) || []
         after_all_hooks.each do |hook|
           hook[:block].call(*args) unless hook[:except].include? method_name
         end
+
+        result
       end
       @adding = false
     end


### PR DESCRIPTION
Currently, methods overridden with a hook will return the result of the `after_all_hook.each do ...` call. This PR saves the return value of the original method and returns it after the after_all_hooks run.